### PR TITLE
Fix code scanning alert no. 64: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -225,7 +225,10 @@ const listAppointment = async (req, res) => {
     try {
 
         const { userId } = req.body
-        const appointments = await appointmentModel.find({ userId })
+        if (typeof userId !== "string") {
+            return res.status(400).json({ success: false, message: "Invalid userId" });
+        }
+        const appointments = await appointmentModel.find({ userId: { $eq: userId } })
 
         res.json({ success: true, appointments })
 


### PR DESCRIPTION
Fixes [https://github.com/prayag78/CureTime/security/code-scanning/64](https://github.com/prayag78/CureTime/security/code-scanning/64)

To fix the problem, we need to ensure that the `userId` is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator, which ensures that the value is interpreted as a literal. Additionally, we should validate that `userId` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
